### PR TITLE
Avoid problem causing coa version (2.1.3 -> 2.0.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "@paysera/react-common": "^3.16.3",
-    "coa": "^2.0.2",
+    "coa": "2.0.2",
     "font-awesome": "^4.7.0",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",


### PR DESCRIPTION
`coa@2.1.3` will fails to install.
Forcing 2.0.2 as suggested in the thread.
Open issue: https://github.com/veged/coa/issues/101